### PR TITLE
Exempt static files from authentication middleware

### DIFF
--- a/startup/middleware/login_required_middleware.py
+++ b/startup/middleware/login_required_middleware.py
@@ -25,6 +25,8 @@ EXEMPT_URLS = [
     r'^sysadmin/verifyOTPSys/.*$',
     r'^sysadmin/ChangePasswordSys/.*$',
     r'^sysadmin/saveForgetMyPasswordSys/.*$',
+    # Static files exemptions
+    r'^static/.*$',            # All static files (JS, CSS, images, fonts, etc.)
 ]
 
 class LoginRequiredMiddleware:


### PR DESCRIPTION
Without this exemption, static assets such as /static/img/cos.ico, /static/css/main.css, etc., are intercepted by authentication middleware. This can cause:
- Broken styling/layout
- Missing images or icons
- Failed JavaScript functionality